### PR TITLE
[PR]toppage bag fix

### DIFF
--- a/app/views/shared/_exhibitionbtn.html.haml
+++ b/app/views/shared/_exhibitionbtn.html.haml
@@ -1,5 +1,11 @@
 //出品ボタン
-= link_to sell_path, class: 'Exhibition__btn' do
-  .Exhibition__btn--text
-    出品
-  = fa_icon 'camera'
+- if user_signed_in? 
+  = link_to sell_path, class: 'Exhibition__btn' do
+    .Exhibition__btn--text
+      出品
+    = fa_icon 'camera'
+- else
+  = link_to signup_path, class: 'Exhibition__btn' do
+    .Exhibition__btn--text
+      出品
+    = fa_icon 'camera'


### PR DESCRIPTION
## what
未ログイン時に、商品出品ができないようにした。

## why
未ログイン状態で商品出品ができると、カラムエラーとなるため

[![Screenshot from Gyazo](https://gyazo.com/bb5a39cc9d085eed126a2050bc3cafcf/raw)](https://gyazo.com/bb5a39cc9d085eed126a2050bc3cafcf)