### PR TITLE
[PR]商品詳細時、未ログインユーザーが購入できないようにした

### DIFF
--- a/app/controllers/mains_controller.rb
+++ b/app/controllers/mains_controller.rb
@@ -6,8 +6,8 @@ class MainsController < ApplicationController
   end
 
   def show
-    sellitem = SellItem.find_by(item_id: @item.id)
-    @user = User.find(sellitem.user_id)
+    @sellitem = SellItem.find_by(item_id: @item.id)
+    @user = User.find(@sellitem.user_id)
   end
   
   

--- a/app/views/mains/show.html.haml
+++ b/app/views/mains/show.html.haml
@@ -69,10 +69,11 @@
           (税込)
         .itempricezone__fee
           送料込み
-      - if user_signed_in?
+      - if user_signed_in? && @sellitem[:user_id] != current_user.id
         = link_to "購入画面に進む",sell_item_show_path(@item.id),class: 'buybtn u-deco-none u-font-white'
       - else
-        = link_to "戻る",root_path
+        = link_to "戻る",root_path, class: 'buybtn u-deco-none u-font-white'
+
       - if @user&.id == current_user&.id
         = link_to '編集', sell_item_edit_path(@item.id),class: 'editBtn u-deco-none u-font-white'
         = link_to '削除', sell_item_delete_path(@item.id), method: :delete ,class: 'deleteBtn u-deco-none u-font-white'

--- a/app/views/mains/show.html.haml
+++ b/app/views/mains/show.html.haml
@@ -69,7 +69,10 @@
           (税込)
         .itempricezone__fee
           送料込み
-      = link_to "購入画面に進む",sell_item_show_path(@item.id),class: 'buybtn u-deco-none u-font-white'
+      - if user_signed_in?
+        = link_to "購入画面に進む",sell_item_show_path(@item.id),class: 'buybtn u-deco-none u-font-white'
+      - else
+        = link_to "戻る",root_path
       - if @user&.id == current_user&.id
         = link_to '編集', sell_item_edit_path(@item.id),class: 'editBtn u-deco-none u-font-white'
         = link_to '削除', sell_item_delete_path(@item.id), method: :delete ,class: 'deleteBtn u-deco-none u-font-white'

--- a/app/views/mains/show.html.haml
+++ b/app/views/mains/show.html.haml
@@ -64,7 +64,7 @@
               = ShipDate.find(@item.ship_date_id).name
       .itempricezone
         .itempricezone__price
-          = "¥#{@item.money}"
+          = "¥#{@item.money.to_s(:delimited)}"
         .itempricezone__tax
           (税込)
         .itempricezone__fee

--- a/app/views/sell_items/show.html.haml
+++ b/app/views/sell_items/show.html.haml
@@ -8,7 +8,7 @@
     .p-buy-main__inner
       .p-buy-main__inner--box
         .item-image
-          = image_tag @item.images.first.image_url.to_s unless @item.images.blank?
+          = image_tag @item.images.first.image_url.to_s ,size: '100x100' unless @item.images.blank?
         .item-detail
           .item-detail__name
             = @item.name
@@ -24,7 +24,7 @@
             .price__display
               支払い金額
             .price__ja
-              = @item.money
+              = '¥' + @item.money.to_s(:delimited)
         %ul.accordion
           %li.accordion__parent
             %input.checkbox{type: "checkbox", id: "checkbox"}

--- a/app/views/sell_items/show.html.haml
+++ b/app/views/sell_items/show.html.haml
@@ -14,7 +14,7 @@
             = @item.name
           .item-detail__price
             .item-detail__price--ja
-              = @item.money
+              = '¥' + @item.money.to_s(:delimited)
             .item-detail__price--fee
               (税込) 送料込み
     .p-buy-content

--- a/app/views/shared/_item_zone.html.haml
+++ b/app/views/shared/_item_zone.html.haml
@@ -43,7 +43,7 @@
                           .l-span-under
                         .l-list-image.u-list-image
                           %span 
-                            = item.money
+                            = '¥' +item.money.to_s(:delimited)
                           = image_tag item.images.first.image_url.to_s unless item.images.blank?
 
       .category__new-items
@@ -66,7 +66,7 @@
                           .l-span-under
                         .l-list-image.u-list-image
                           %span 
-                            = item.money
+                            = '¥' +item.money.to_s(:delimited)
                           = image_tag item.images.first.image_url.to_s unless item.images.blank?
       .category__new-items
         .category__new-items--inner
@@ -88,7 +88,7 @@
                           .l-span-under
                         .l-list-image.u-list-image
                           %span 
-                            = item.money
+                            = '¥' +item.money.to_s(:delimited)
                           = image_tag item.images.first.image_url.to_s unless item.images.blank?
       .category__new-items
         .category__new-items--inner
@@ -110,7 +110,7 @@
                           .l-span-under
                         .l-list-image.u-list-image
                           %span 
-                            = item.money
+                            = '¥' +item.money.to_s(:delimited)
                           = image_tag item.images.first.image_url.to_s unless item.images.blank?
     .category
       %h2.category__title
@@ -150,7 +150,7 @@
                           .l-span-under
                         .l-list-image.u-list-image
                           %span 
-                            = item.money
+                            = '¥' +item.money.to_s(:delimited)
                           = image_tag item.images.first.image_url.to_s unless item.images.blank?
       .category__new-items
         .category__new-items--inner
@@ -172,7 +172,7 @@
                           .l-span-under
                         .l-list-image.u-list-image
                           %span 
-                            = item.money
+                            = '¥' +item.money.to_s(:delimited)
                           = image_tag item.images.first.image_url.to_s unless item.images.blank?
       .category__new-items
         .category__new-items--inner
@@ -194,7 +194,7 @@
                           .l-span-under
                         .l-list-image.u-list-image
                           %span 
-                            = item.money
+                            = '¥' +item.money.to_s(:delimited)
                           = image_tag item.images.first.image_url.to_s unless item.images.blank?
         .category__new-items--inner
           %h3.category__new-items--inner--title.l-title-h3 ナイキ新着アイテム
@@ -215,5 +215,5 @@
                           .l-span-under
                         .l-list-image.u-list-image
                           %span 
-                            = item.money
+                            = '¥' +item.money.to_s(:delimited)
                           = image_tag item.images.first.image_url.to_s unless item.images.blank?


### PR DESCRIPTION
## what
商品詳細時、未ログインユーザーが購入できないようにした
## why
購入画面に飛ぶと、カラムエラーとなるため

[![Screenshot from Gyazo](https://gyazo.com/cf83713ac78c5e20942e3a9c9a058247/raw)](https://gyazo.com/cf83713ac78c5e20942e3a9c9a058247)