### PR TITLE
Add クレジットカード登録後に遷移元に戻る処理

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -6,6 +6,7 @@ class CardsController < ApplicationController
     add_breadcrumb 'マイページ', mypage_path
     add_breadcrumb '支払い方法', mypage_card_create_path
     add_breadcrumb 'クレジットカード情報入力'
+    session[:previous_page] = request.referer
     card = Card.where(user_id: current_user.id)
     redirect_to action: 'index' if card.exists?
     year = Time.now.year
@@ -29,7 +30,7 @@ class CardsController < ApplicationController
       customer = Payjp::Customer.create(card: params['payjp-token'])
       @card = Card.new(user_id: current_user.id, customer_id: customer.id, card_id: customer.default_card)
       if @card.save
-        redirect_to action: 'index'
+        redirect_to session[:previous_page]
       else
         redirect_to action: 'pay'
       end


### PR DESCRIPTION
# What
商品購入画面から、クレジットカード登録画面に遷移し、登録後、元の購入画面に戻らない点を改善

# How
sessionを用いて、実装しました。ウィザード形式も同じようにやれば、実現できると思います。
![session](https://user-images.githubusercontent.com/54176946/77825085-6e48ba00-714a-11ea-83ae-9a36c971f629.gif)
